### PR TITLE
Display help when ran without any arguments

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,5 @@
+Gistit contributors
+===================
+
+Hanish K H <hanish0019<at>gmail<dot>com>
+

--- a/gistit.py
+++ b/gistit.py
@@ -98,6 +98,9 @@ def make_parser():
 def main():
     parser = make_parser()
     args = parser.parse_args()
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
     command = args.func
     sys.exit(command(args))
 

--- a/gistit.py
+++ b/gistit.py
@@ -320,7 +320,7 @@ class ReadmeUsageTestCase(unittest.TestCase):
 
         cmd_args = [sys.executable, 'gistit.py']
         cmd_args.extend(args)
-        output_lines = subprocess.check_output(cmd_args).decode('utf-8').splitlines()
+        output_lines = subprocess.check_output(cmd_args).splitlines()
         output_lines = [line.rstrip() for line in output_lines]
         indented_output_lines = []
         for line in output_lines:
@@ -342,12 +342,14 @@ class ReadmeUsageTestCase(unittest.TestCase):
 class SimpleRun(unittest.TestCase):
     def setUp(self):
         cmd_args = [sys.executable, 'gistit.py', '--help']
-        args = make_parser().parse_args([])
-        self.help_output_lines = subprocess.check_output(cmd_args).decode('utf-8').splitlines()
+        self.help_output_lines = subprocess.Popen(
+            cmd_args,
+            stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
 
     def test_no_args(self):
         cmd_args = [sys.executable, 'gistit.py']
-        args = make_parser().parse_args([])
-        self.test_output_lines = subprocess.check_output(cmd_args).decode('utf-8').splitlines()
+        self.test_output_lines = subprocess.Popen(
+            cmd_args,
+            stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
         self.assertTrue(self.help_output_lines == self.test_output_lines)
 

--- a/gistit.py
+++ b/gistit.py
@@ -320,7 +320,7 @@ class ReadmeUsageTestCase(unittest.TestCase):
 
         cmd_args = [sys.executable, 'gistit.py']
         cmd_args.extend(args)
-        output_lines = subprocess.check_output(cmd_args).splitlines()
+        output_lines = subprocess.check_output(cmd_args).decode('utf-8').splitlines()
         output_lines = [line.rstrip() for line in output_lines]
         indented_output_lines = []
         for line in output_lines:
@@ -338,3 +338,16 @@ class ReadmeUsageTestCase(unittest.TestCase):
 
     def test_create(self):
         self.assertReadmeContainsOutput(['create', '-h'])
+
+class SimpleRun(unittest.TestCase):
+    def setUp(self):
+        cmd_args = [sys.executable, 'gistit.py', '--help']
+        args = make_parser().parse_args([])
+        self.help_output_lines = subprocess.check_output(cmd_args).decode('utf-8').splitlines()
+
+    def test_no_args(self):
+        cmd_args = [sys.executable, 'gistit.py']
+        args = make_parser().parse_args([])
+        self.test_output_lines = subprocess.check_output(cmd_args).decode('utf-8').splitlines()
+        self.assertTrue(self.help_output_lines == self.test_output_lines)
+

--- a/gistit.py
+++ b/gistit.py
@@ -100,7 +100,7 @@ def main():
     args = parser.parse_args()
     if args.command is None:
         parser.print_help()
-        sys.exit(1)
+        parser.exit(1)
     command = args.func
     sys.exit(command(args))
 
@@ -358,5 +358,5 @@ class SimpleRun(unittest.TestCase):
         self.test_output_lines = subprocess.Popen(
             cmd_args,
             stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
-        self.assertTrue(self.help_output_lines == self.test_output_lines)
+        self.assertEqual(self.help_output_lines, self.test_output_lines)
 

--- a/gistit.py
+++ b/gistit.py
@@ -360,10 +360,10 @@ class SimpleRun(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         test_stdout, test_stderr = proc.communicate()
-        test_output_line = ''
         # using `stdout`/`stderr` because in `python2` the default help is raised
         # by the parser, and it is written to `stderr`, while in `python3` we
         # are using the parser to print help explicitly and it being written to stdout
+        test_output_line = ''
         if test_stdout:
             test_output_line = test_stdout.decode('utf-8').splitlines()[0]
         else:


### PR DESCRIPTION
If ran without any arguments, it will raise the error:

```
  gistenv  ~/.../tkinter/cdunklu  ./gistit.py
Traceback (most recent call last):
  File "./gistit.py", line 245, in <module>
    main()
  File "./gistit.py", line 104, in main
    command = args.func
AttributeError: 'Namespace' object has no attribute 'func'
 ✘   gistenv  ~/.../tkinter/cdunklu  
```